### PR TITLE
Fix fungame black screen on revisit: run game in iframe

### DIFF
--- a/src/routes/fungame/+page.svelte
+++ b/src/routes/fungame/+page.svelte
@@ -1,24 +1,14 @@
-<script>
-  import { onMount } from 'svelte';
-
-  onMount(() => {
-    const script = document.createElement('script');
-    script.src = 'https://not-fl3.github.io/miniquad-samples/mq_js_bundle.js';
-    script.onload = () => {
-      if (typeof load === 'function') {
-        load('/fungame.wasm');
-      }
-    };
-    document.head.appendChild(script);
-  });
-</script>
-
 <svelte:head>
-  <title>TITLE</title>
+  <title>fungame</title>
 </svelte:head>
 
 <div class="fungame-container">
-  <canvas id="glcanvas" tabindex="1"></canvas>
+  <a href="/" class="back-link">← Home</a>
+  <iframe
+    class="fungame-iframe"
+    title="Fun Game"
+    src="/fungame.html"
+  />
 </div>
 
 <style>
@@ -34,9 +24,25 @@
     background: black;
     z-index: 0;
   }
-  .fungame-container :global(canvas) {
+  .fungame-iframe {
+    display: block;
     width: 100%;
     height: 100%;
-    display: block;
+    border: none;
+  }
+  .back-link {
+    position: absolute;
+    top: 0.75rem;
+    left: 0.75rem;
+    z-index: 1;
+    color: #fff;
+    text-decoration: none;
+    font-size: 0.9rem;
+    padding: 0.35rem 0.6rem;
+    background: rgba(0, 0, 0, 0.5);
+    border-radius: 0.25rem;
+  }
+  .back-link:hover {
+    background: rgba(0, 0, 0, 0.75);
   }
 </style>

--- a/static/fungame.html
+++ b/static/fungame.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1">
+  <style>
+    html, body, canvas { margin: 0; padding: 0; width: 100%; height: 100%; overflow: hidden; background: #000; }
+  </style>
+</head>
+<body>
+  <canvas id="glcanvas" tabindex="1"></canvas>
+  <script src="https://not-fl3.github.io/miniquad-samples/mq_js_bundle.js"></script>
+  <script>load("/fungame.wasm");</script>
+</body>
+</html>


### PR DESCRIPTION
Load the game in an iframe (static/fungame.html) so the macroquad script runs in an isolated document. Each visit gets a fresh iframe and fresh JS context, avoiding 'redeclaration of const' when navigating Home -> Fun Game -> Home -> Fun Game.

- Add static/fungame.html with canvas + mq_js_bundle + load()
- Replace inline script injection in +page.svelte with iframe